### PR TITLE
[18Chesapeake: Off the Rails] Add base game rules link to meta.rb (#1)

### DIFF
--- a/lib/engine/game/g_18_chesapeake_off_the_rails/meta.rb
+++ b/lib/engine/game/g_18_chesapeake_off_the_rails/meta.rb
@@ -15,7 +15,12 @@ module Engine
         GAME_DESIGNER = 'Scott Petersen'
         GAME_INFO_URL = 'https://github.com/tobymao/18xx/wiki/18Chesapeake'
         GAME_PUBLISHER = :all_aboard_games
-        GAME_RULES_URL = 'https://www.dropbox.com/s/ivm4jsopnzabhru/18ChesOTR_Rules.png?dl=0'
+        GAME_RULES_URL = {
+          'Base 18Chesapeake Rules' =>
+          'https://cdn.shopify.com/s/files/1/0252/9371/7588/files/18Chesapeake.pdf?v=1597256917',
+          'Off the Rails Expansion Rules' =>
+            'https://www.dropbox.com/s/ivm4jsopnzabhru/18ChesOTR_Rules.png?dl=0',
+        }.freeze
         GAME_TITLE = '18Chesapeake: Off the Rails'
         GAME_ALIASES = %w[OTR 18ChesapeakeOTR].freeze
         GAME_IS_VARIANT_OF = G18Chesapeake::Meta


### PR DESCRIPTION
Add base game rules link to 18Chesapeake: Off the Rails meta.rb

Fixes #[PUT_ISSUE_NUMBER_HERE]

<!--

Please minimize the amount of changes to shared `lib/engine` code, if possible

If you are implementing a new game, please break up the changes into multiple PRs for ease of review.

-->

### Before clicking "Create"

- [ ] Branch is derived from the latest `master`
- [ ] Add the `pins` label if this change will break existing games
- [ ] Code passes linter with `docker compose exec rack rubocop -a`
- [ ] Tests pass cleanly with `docker compose exec rack rake`

### Implementation Notes

* **Explanation of Change**

* **Screenshots**

* **Any Assumptions / Hacks**
