### PR TITLE
Link Chesapeake: Off the Rails directly to it's respective github wik…

### DIFF
--- a/lib/engine/game/g_18_chesapeake_off_the_rails/meta.rb
+++ b/lib/engine/game/g_18_chesapeake_off_the_rails/meta.rb
@@ -13,7 +13,7 @@ module Engine
         DEPENDS_ON = '18Chesapeake'
 
         GAME_DESIGNER = 'Scott Petersen'
-        GAME_INFO_URL = 'https://github.com/tobymao/18xx/wiki/18Chesapeake'
+        GAME_INFO_URL = 'https://github.com/tobymao/18xx/wiki/18Chesapeake%3A-Off-the-Rails'
         GAME_PUBLISHER = :all_aboard_games
         GAME_RULES_URL = 'https://www.dropbox.com/s/ivm4jsopnzabhru/18ChesOTR_Rules.png?dl=0'
         GAME_TITLE = '18Chesapeake: Off the Rails'


### PR DESCRIPTION
…i entry

This PR links Off the Rail to it's respective wiki page.  From there users can navigate to the base game wiki entry if need be

Fixes #[PUT_ISSUE_NUMBER_HERE]

<!--

Please minimize the amount of changes to shared `lib/engine` code, if possible

If you are implementing a new game, please break up the changes into multiple PRs for ease of review.

-->

### Before clicking "Create"

- [ ] Branch is derived from the latest `master`
- [ ] Add the `pins` label if this change will break existing games
- [ ] Code passes linter with `docker compose exec rack rubocop -a`
- [ ] Tests pass cleanly with `docker compose exec rack rake`

### Implementation Notes

* **Explanation of Change**

* **Screenshots**

* **Any Assumptions / Hacks**
